### PR TITLE
Made the code compatible with java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>com.adobe.event</groupId>
   <artifactId>xdm-event-model</artifactId>
-  <version>0.92.7-SNAPSHOT</version>
+  <version>0.92.6-SNAPSHOT</version>
 
   <name>Adobe XDM Event Model</name>
   <description>Adobe I/O Event Java (Jackson based) Implementation of the Adobe XDM Event Model</description>
@@ -67,7 +67,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <jackson.version>2.10.0</jackson.version>
@@ -268,6 +268,38 @@
       </plugins>
     </build>
   </profile>
+    <profile>
+      <id>java8</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <java.version>1.8</java.version>
+        <java.version.classifier>java8</java.version.classifier>
+      </properties>
+      <dependencies>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.2.0</version>
+            <configuration>
+              <classifier>${java.version.classifier}</classifier>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>${maven.compiler.source}</source>
+              <target>${maven.compiler.target}</target>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>com.adobe.event</groupId>
   <artifactId>xdm-event-model</artifactId>
-  <version>0.92.7-SNAPSHOT</version>
+  <version>0.92.6-SNAPSHOT</version>
 
   <name>Adobe XDM Event Model</name>
   <description>Adobe I/O Event Java (Jackson based) Implementation of the Adobe XDM Event Model</description>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>com.adobe.event</groupId>
   <artifactId>xdm-event-model</artifactId>
-  <version>0.92.6-SNAPSHOT</version>
+  <version>0.92.7-SNAPSHOT</version>
 
   <name>Adobe XDM Event Model</name>
   <description>Adobe I/O Event Java (Jackson based) Implementation of the Adobe XDM Event Model</description>
@@ -67,7 +67,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>11</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <jackson.version>2.10.0</jackson.version>
@@ -268,38 +268,6 @@
       </plugins>
     </build>
   </profile>
-    <profile>
-      <id>java8</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <java.version>1.8</java.version>
-        <java.version.classifier>java8</java.version.classifier>
-      </properties>
-      <dependencies>
-      </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jar-plugin</artifactId>
-            <version>3.2.0</version>
-            <configuration>
-              <classifier>${java.version.classifier}</classifier>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>${maven.compiler.source}</source>
-              <target>${maven.compiler.target}</target>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <groupId>com.adobe.event</groupId>
   <artifactId>xdm-event-model</artifactId>
-  <version>0.92.6-SNAPSHOT</version>
+  <version>0.92.7-SNAPSHOT</version>
 
   <name>Adobe XDM Event Model</name>
   <description>Adobe I/O Event Java (Jackson based) Implementation of the Adobe XDM Event Model</description>
@@ -67,7 +67,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>11</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <jackson.version>2.10.0</jackson.version>


### PR DESCRIPTION
## Description
Made the code compatible with java 8. This is required to make https://github.com/adobe/aio-lib-java work with java 8 

## Related Issue
The issue https://github.com/adobe/aio-lib-java/issues/104 is in the aio-lib-java repo which is for making the sdk compatiable with Java 8.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Please list as well any other related PRs/commits in other repositories (or any other dependencies) -->

## Motivation and Context
AEM Guides addon is not yet on Java 11 but needs integration with IO Events. This change will help Guides to use the SDK without being forced to migrate to Java 11.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I tested the changes by deploying my publisher and consumer which were working with java 11 and tested them using the version which was migrated to java 8.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] the Maven local build completes: `mvn install` completes i.e. the build is successful 
- [ ] the OSGI Maven local build completes: `mvn -f pom-bundle.xml clean install` completes i.e. the OSGI build is successful 




